### PR TITLE
Removes the unused reference to laravel's event dispacther

### DIFF
--- a/src/TenantServiceProvider.php
+++ b/src/TenantServiceProvider.php
@@ -1,7 +1,6 @@
 <?php
 namespace ThinkSayDo\EnvTenant;
 
-use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Support\ServiceProvider;
 
 class TenantServiceProvider extends ServiceProvider


### PR DESCRIPTION
Removes the unused reference to the laravel's event dispatcher class in the tenant service provider.